### PR TITLE
Pin nodegit to a specific version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-runtime": "^6.6.1",
     "event-kit": "^2.0.0",
     "fs-plus": "^2.8.2",
-    "nodegit": "^0.13.0",
+    "nodegit": "0.13.0",
     "underscore-plus": "^1.6.6"
   }
 }


### PR DESCRIPTION
Since nodegit is still making breaking changes, we can’t rely on semantic versioning. Just pin the version.
